### PR TITLE
Update electron to 1.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@types/node": {
-            "version": "7.0.52",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.52.tgz",
-            "integrity": "sha512-jjpyQsKGsOF/wUElNjfPULk+d8PKvJOIXk3IUeBYYmNCy5dMWfrI+JiixYNw8ppKOlcRwWTXFl0B+i5oGrf95Q==",
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.0.tgz",
+            "integrity": "sha512-7IGHZQfRfa0bCd7zUBVUGFKFn31SpaLDFfNoCAqkTGQO5JlHC9BwQA/CG9KZlABFxIUtXznyFgechjPQEGrUTg==",
             "dev": true
         },
         "abbrev": {
@@ -311,7 +311,7 @@
             "dev": true,
             "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.3.5",
                 "typedarray": "0.0.6"
             },
             "dependencies": {
@@ -321,16 +321,22 @@
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true
                 },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
                 "readable-stream": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "1.0.2",
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
+                        "process-nextick-args": "2.0.0",
                         "safe-buffer": "5.1.1",
                         "string_decoder": "1.0.3",
                         "util-deprecate": "1.0.2"
@@ -481,12 +487,12 @@
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "electron": {
-            "version": "1.7.11",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.11.tgz",
-            "integrity": "sha1-mTtqp54OeafPzDafTIE/vZoLCNk=",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.4.tgz",
+            "integrity": "sha512-2f1cx0G3riMFODXFftF5AHXy+oHfhpntZHTDN66Hxtl09gmEr42B3piNEod9MEmw72f75LX2JfeYceqq1PF8cA==",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.52",
+                "@types/node": "8.10.0",
                 "electron-download": "3.3.0",
                 "extract-zip": "1.6.6"
             }
@@ -503,7 +509,7 @@
                 "minimist": "1.2.0",
                 "nugget": "2.0.1",
                 "path-exists": "2.1.0",
-                "rc": "1.2.4",
+                "rc": "1.2.6",
                 "semver": "5.5.0",
                 "sumchecker": "1.3.1"
             }
@@ -1569,9 +1575,9 @@
             }
         },
         "rc": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
-            "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+            "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
             "dev": true,
             "requires": {
                 "deep-extend": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "Electron"
     ],
     "devDependencies": {
-        "electron": "~1.7.8",
+        "electron": "^1.8.4",
         "electron-rebuild": "^1.7.3"
     },
     "dependencies": {


### PR DESCRIPTION
This update is required to patch the following vulnerabilities...

* CVE-2018-1000136
* CVE-2018-1000118

[#41]