### PR TITLE
Require messagebus from main process

### DIFF
--- a/js/input_checker.js
+++ b/js/input_checker.js
@@ -1,5 +1,7 @@
+const remote = require('electron').remote;
+
 const getopts = require('getopts');
-const messagebus = require('./js/messagebus');
+const messagebus = remote.require('./js/messagebus');
 
 let prompt = ['$', '#', '+'];
 

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -1,9 +1,11 @@
+const remote = require('electron').remote;
+
 const os = require('os');
 const pty = require('node-pty');
 const Terminal = require('xterm').Terminal;
 const fit = require('xterm/lib/addons/fit/fit');
 const KeyCode = require('keycode-js');
-const messagebus = require('./js/messagebus');
+const messagebus = remote.require('./js/messagebus');
 
 // Initialize a shell process
 let shell = process.env[os.platform() === 'win32' ? 'COMSPEC' : 'SHELL'];


### PR DESCRIPTION
Previously we were requiring the messagebus from each renderer process.
However, due to the nature of electron, this meant each module was
getting its own unique instance of the messagebus. By requiring from the
main process, we ensure each module gets the same messagebus instance.

[#43]