### PR TITLE
Fixed webview console logging

### DIFF
--- a/js/mainview.js
+++ b/js/mainview.js
@@ -48,3 +48,8 @@ document.getElementById('contributionviewicon').onclick = () => {
     ptyProcess.write(runGitstatsCommand);
     setTimeout(ipcRenderer.send('open-contribution-window'), 3000);
 }
+
+const webviews = document.querySelectorAll('webview');
+webviews.forEach(wv => wv.addEventListener('console-message', (e) => {
+  console.log(e.message)
+}));


### PR DESCRIPTION
Currently no log messages from terminal or visualizer show up inside mainview. This is because webview logging is disabled by default. This change fixes that.