### PR TITLE
Clear typed characters before printing error

### DIFF
--- a/js/input-checker.js
+++ b/js/input-checker.js
@@ -15,6 +15,8 @@ function inputChecker(command) {
     if (!safetyCheck.pass) {
         console.log(safetyCheck.errMsg);
         messagebus.sendMessage("block", "terminal");
+    } else {
+        messagebus.sendMessage("unblock", "terminal")
     }
 }
 

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -21,7 +21,10 @@ let xterm = new Terminal({
     cursorBlink: true,
 });
 
+let commandToExecute = null;
+let errorMessage = null;
 let isBlocked = false;
+let receiveCount = -1;
 
 /**
  * Handle messages from the messagebus
@@ -32,6 +35,8 @@ function handleMessage(message) {
     if (message === "block") {
         isBlocked = true;
     }
+    receiveCount += 1;
+    runCommand();
 }
 
 messagebus.subscribe(handleMessage, "terminal");
@@ -40,27 +45,46 @@ xterm.open(document.getElementById('terminal'));
 fit.fit(xterm);
 
 xterm.on('data', (data) => {
+    if (receiveCount > -1) return;
     // Check user command after pressing enter
     if (data.charCodeAt(0) === KeyCode.KEY_RETURN) {
         let lineIdx = xterm.buffer.y + xterm.buffer.ybase;
         let currLine = xterm.buffer.lines._array[lineIdx];
 
-        currLine = currLine.map((arrElement) => {
+        commandToExecute = currLine.map((arrElement) => {
             return arrElement[1];
         }).join("");
 
-        messagebus.sendMessage(currLine, "command");
-        if (!isBlocked) {
-            ptyProcess.write(data);
-        } else {
-            isBlocked = false;
-        }
+        receiveCount += 1;
+        messagebus.sendMessage(commandToExecute, "command");
     } else { // If user didn't press enter, pass the input to the shell
         ptyProcess.write(data);
     }
 });
 
+/**
+ * Run command queued up in commandToExecute, if safe.
+ * Print error otherwise.
+ */
+function runCommand() {
+    if (receiveCount < 1) return;
+    if (!isBlocked) {
+        ptyProcess.write('\n');
+    } else {
+        let backspaces = Array(commandToExecute.length).join('\b');
+        ptyProcess.write(backspaces)
+        errorMessage = '\n\rError';
+        isBlocked = false;
+    }
+    receiveCount = -1;
+}
+
 // Send the shell output to the front end
 ptyProcess.on('data', (data) => {
     xterm.write(data);
+    if (errorMessage) {
+        xterm.write(errorMessage);
+        errorMessage = null;
+        ptyProcess.write('\n');
+    }
 });


### PR DESCRIPTION
Prior to this change, characters were never deleted from ptyProcess
causing unpredictable behaviour after a command was blocked. Further,
this change adds error printing when a command is blocked.

[#58]